### PR TITLE
fix: SARIF output valid schema for GitHub upload

### DIFF
--- a/docs/output.html
+++ b/docs/output.html
@@ -314,7 +314,7 @@ jobs:
       <span class="comment">#     ssh user@server "curl -sL .../install.sh | sh && sudo infraudit audit --format sarif" > results.sarif</span>
 
       - name: Upload SARIF to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif</code></pre>
 

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -50,7 +50,6 @@ type sarifResult struct {
 	Level     string          `json:"level"`
 	Message   sarifMessage    `json:"message"`
 	Locations []sarifLocation `json:"locations,omitempty"`
-	Fixes     []sarifFix      `json:"fixes,omitempty"`
 }
 
 type sarifMessage struct {
@@ -72,10 +71,6 @@ type sarifArtifactLocation struct {
 
 type sarifRegion struct {
 	StartLine int `json:"startLine"`
-}
-
-type sarifFix struct {
-	Description sarifMessage `json:"description"`
 }
 
 // WriteSARIF writes the report in SARIF 2.1.0 format.
@@ -106,10 +101,14 @@ func WriteSARIF(w io.Writer, r *Report) error {
 		if e.Status == "PASS" {
 			continue
 		}
-		result := sarifResult{
+		msg := e.Message
+		if e.Remediation != "" {
+			msg += ". Remediation: " + e.Remediation
+		}
+		results = append(results, sarifResult{
 			RuleID:  e.ID,
 			Level:   statusToLevel(e.Status),
-			Message: sarifMessage{Text: e.Message},
+			Message: sarifMessage{Text: msg},
 			Locations: []sarifLocation{
 				{
 					PhysicalLocation: sarifPhysicalLocation{
@@ -120,13 +119,7 @@ func WriteSARIF(w io.Writer, r *Report) error {
 					},
 				},
 			},
-		}
-		if e.Remediation != "" {
-			result.Fixes = []sarifFix{
-				{Description: sarifMessage{Text: e.Remediation}},
-			}
-		}
-		results = append(results, result)
+		})
 	}
 
 	doc := sarifDocument{

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -62,11 +62,10 @@ func TestWriteSARIF(t *testing.T) {
 	if run.Results[0].Level != "error" {
 		t.Errorf("result[0].level = %q, want error", run.Results[0].Level)
 	}
-	if len(run.Results[0].Fixes) != 1 {
-		t.Fatalf("result[0].fixes = %d, want 1", len(run.Results[0].Fixes))
-	}
-	if run.Results[0].Fixes[0].Description.Text != "Set PermitRootLogin no" {
-		t.Errorf("fix text = %q", run.Results[0].Fixes[0].Description.Text)
+	// Message should include remediation
+	wantMsg := "Root login enabled. Remediation: Set PermitRootLogin no"
+	if run.Results[0].Message.Text != wantMsg {
+		t.Errorf("result[0].message = %q, want %q", run.Results[0].Message.Text, wantMsg)
 	}
 
 	// NET-001 should be "warning" level


### PR DESCRIPTION
## Summary

Fix SARIF output to produce valid schema accepted by `github/codeql-action/upload-sarif`.

The `fixes[]` field requires `artifactChanges` (code patches), which doesn't apply to infrastructure remediation. Remediation text is now included in the `message` field instead.

## Changes

- Remove `fixes` field and `sarifFix` struct from SARIF output
- Append remediation to message: `"Root login enabled. Remediation: Set PermitRootLogin no"`
- Update docs to use `codeql-action@v4`
- Update tests to match new structure

## Test plan

- [x] `go build` compiles
- [x] `go test ./...` — all pass
- [x] `go vet` — clean
- [x] `golangci-lint` — 0 issues
- [x] Validated with real GitHub upload-sarif action on `test/sarif-demo` branch