### PR TITLE
feat: add SVC-057 Redis authentication check

### DIFF
--- a/internal/checks/services/redis.go
+++ b/internal/checks/services/redis.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"os"
+	"strings"
+
+	"github.com/civanmoreno/infraudit/internal/check"
+)
+
+func init() {
+	check.Register(&redisAuth{})
+}
+
+// SVC-057: Redis requires authentication
+type redisAuth struct{}
+
+func (c *redisAuth) ID() string               { return "SVC-057" }
+func (c *redisAuth) Name() string             { return "Redis requires authentication" }
+func (c *redisAuth) Category() string         { return "services" }
+func (c *redisAuth) Severity() check.Severity { return check.High }
+func (c *redisAuth) Description() string {
+	return "Ensure Redis is configured with requirepass to prevent unauthenticated access"
+}
+
+func (c *redisAuth) Run() check.Result {
+	configPaths := []string{
+		"/etc/redis/redis.conf",
+		"/etc/redis.conf",
+	}
+
+	var found string
+	for _, p := range configPaths {
+		if _, err := os.Stat(check.P(p)); err == nil {
+			found = p
+			break
+		}
+	}
+
+	if found == "" {
+		return check.Result{
+			Status:  check.Pass,
+			Message: "Redis is not installed or no config file found",
+		}
+	}
+
+	data, err := os.ReadFile(check.P(found))
+	if err != nil {
+		return check.Result{
+			Status:      check.Error,
+			Message:     "Cannot read Redis config: " + err.Error(),
+			Remediation: "Run infraudit with sudo for full results",
+		}
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "requirepass ") {
+			pass := strings.TrimPrefix(line, "requirepass ")
+			pass = strings.TrimSpace(pass)
+			if pass != "" && pass != `""` && pass != "''" {
+				return check.Result{
+					Status:  check.Pass,
+					Message: "Redis requirepass is configured",
+				}
+			}
+		}
+	}
+
+	return check.Result{
+		Status:      check.Fail,
+		Message:     "Redis does not require authentication (" + found + ")",
+		Remediation: "Set 'requirepass <strong-password>' in " + found + " and restart Redis",
+	}
+}

--- a/internal/checks/services/redis_test.go
+++ b/internal/checks/services/redis_test.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/civanmoreno/infraudit/internal/check"
+)
+
+func TestRedisAuth_NotInstalled(t *testing.T) {
+	tmp := setupFSRoot(t)
+	_ = tmp // no redis config created
+
+	c := &redisAuth{}
+	r := c.Run()
+	if r.Status != check.Pass {
+		t.Errorf("expected PASS when Redis not installed, got %s: %s", r.Status, r.Message)
+	}
+}
+
+func TestRedisAuth_RequirepassSet(t *testing.T) {
+	tmp := setupFSRoot(t)
+	writeFile(t, tmp, "etc/redis/redis.conf", `# Redis config
+bind 127.0.0.1
+port 6379
+requirepass s3cur3P@ssw0rd!
+`)
+
+	c := &redisAuth{}
+	r := c.Run()
+	if r.Status != check.Pass {
+		t.Errorf("expected PASS with requirepass set, got %s: %s", r.Status, r.Message)
+	}
+}
+
+func TestRedisAuth_NoRequirepass(t *testing.T) {
+	tmp := setupFSRoot(t)
+	writeFile(t, tmp, "etc/redis/redis.conf", `# Redis config
+bind 127.0.0.1
+port 6379
+# requirepass is commented out
+`)
+
+	c := &redisAuth{}
+	r := c.Run()
+	if r.Status != check.Fail {
+		t.Errorf("expected FAIL without requirepass, got %s: %s", r.Status, r.Message)
+	}
+	if r.Remediation == "" {
+		t.Error("expected remediation message")
+	}
+}
+
+func TestRedisAuth_EmptyRequirepass(t *testing.T) {
+	tmp := setupFSRoot(t)
+	writeFile(t, tmp, "etc/redis/redis.conf", `bind 127.0.0.1
+requirepass ""
+`)
+
+	c := &redisAuth{}
+	r := c.Run()
+	if r.Status != check.Fail {
+		t.Errorf("expected FAIL with empty requirepass, got %s: %s", r.Status, r.Message)
+	}
+}
+
+func TestRedisAuth_AlternateConfigPath(t *testing.T) {
+	tmp := setupFSRoot(t)
+	writeFile(t, tmp, "etc/redis.conf", `requirepass mypassword
+`)
+
+	c := &redisAuth{}
+	r := c.Run()
+	if r.Status != check.Pass {
+		t.Errorf("expected PASS with /etc/redis.conf, got %s: %s", r.Status, r.Message)
+	}
+}
+
+func TestRedisAuth_Metadata(t *testing.T) {
+	c := &redisAuth{}
+	if c.ID() != "SVC-057" {
+		t.Errorf("ID = %q, want SVC-057", c.ID())
+	}
+	if c.Category() != "services" {
+		t.Errorf("Category = %q, want services", c.Category())
+	}
+	if c.Severity() != check.High {
+		t.Errorf("Severity = %v, want HIGH", c.Severity())
+	}
+}

--- a/internal/compliance/cis.go
+++ b/internal/compliance/cis.go
@@ -125,6 +125,9 @@ var CISControls = []CISControl{
 	{CheckID: "SVC-010", Section: "2.2.3", SectionName: "Ensure MTA is not an open relay", Category: "2. Services", Level: L1},
 	{CheckID: "SVC-011", Section: "2.2.4", SectionName: "Ensure root mail is forwarded to a monitored account", Category: "2. Services", Level: L1},
 
+	// 2.2.6 Application-specific services
+	{CheckID: "SVC-057", Section: "2.2.6", SectionName: "Ensure Redis requires authentication", Category: "2. Services", Level: L1},
+
 	// 2.3 NFS/RPC
 	{CheckID: "NFS-001", Section: "2.3.1", SectionName: "Ensure NFS exports are properly configured", Category: "2. Services", Level: L1},
 	{CheckID: "NFS-002", Section: "2.3.2", SectionName: "Ensure NFSv3 is disabled if NFSv4 is available", Category: "2. Services", Level: L1},


### PR DESCRIPTION
## Descripción

Nuevo check SVC-057 que verifica que Redis requiera autenticación via `requirepass`. Sin esta configuración, cualquier proceso en la red puede acceder y modificar datos en Redis.

## Tipo de Cambio

- [ ] Bug fix
- [x] Nuevo check
- [ ] Nueva funcionalidad
- [ ] Refactor
- [ ] Documentación
- [x] Tests
- [ ] CI/CD

## Checklist

- [x] `make test` pasa (todos los tests)
- [x] `make lint` pasa (0 issues en golangci-lint)
- [x] He agregado tests para los cambios nuevos
- [ ] La documentación está actualizada (si aplica)
- [x] Los checks nuevos tienen mapeo CIS en `internal/compliance/cis.go` (si aplica)
- [x] Los checks nuevos usan `check.P()` para rutas de archivos (testabilidad)
- [x] Los checks específicos de OS tienen anotaciones `SupportedOS`/`RequiredInit`

## Checks Nuevos (si aplica)

| ID | Nombre | Categoría | Severidad |
|----|--------|-----------|-----------|
| SVC-057 | Redis requires authentication | services | HIGH |

## Test Plan

- [x] `TestRedisAuth_NotInstalled` — PASS cuando Redis no está instalado
- [x] `TestRedisAuth_RequirepassSet` — PASS cuando requirepass tiene valor
- [x] `TestRedisAuth_NoRequirepass` — FAIL cuando requirepass no existe
- [x] `TestRedisAuth_EmptyRequirepass` — FAIL cuando requirepass está vacío
- [x] `TestRedisAuth_AlternateConfigPath` — PASS con /etc/redis.conf
- [x] `TestRedisAuth_Metadata` — Verifica ID, categoría, severidad